### PR TITLE
Support JSON chain spec for parachain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-web3/parachain-launch",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Laminar Developers <hello@laminar.one>",
   "license": "Apache-2.0",
   "main": "lib/index.js",


### PR DESCRIPTION
This PR tries to:
- add support to JSON chain spec for parachain:
   For example, you can now put `/home/foo/bar/chainspec.json` in the parachain.chain section
- add support to absolute path for output directory
- refactor the chain spec name construction via `getChainspecName`