### PR TITLE
Fix hrmp channels handling for polkadot chainspec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,8 +198,8 @@ const generateRelaychainGenesisFile = (config: Config, path: string, output: str
         }
       });
     }
-    _.merge((runtime.runtime_genesis_config || runtime), config.relaychain.runtimeGenesisConfig);
-    _.merge((runtime.runtime_genesis_config || runtime), config.relaychain.overrides);
+    _.merge(runtime.runtime_genesis_config || runtime, config.relaychain.runtimeGenesisConfig);
+    _.merge(runtime.runtime_genesis_config || runtime, config.relaychain.overrides);
   }
 
   // genesis parachains

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,8 +198,8 @@ const generateRelaychainGenesisFile = (config: Config, path: string, output: str
         }
       });
     }
-    _.merge(runtime.runtime_genesis_config, config.relaychain.runtimeGenesisConfig);
-    _.merge(runtime, config.relaychain.overrides);
+    _.merge((runtime.runtime_genesis_config || runtime), config.relaychain.runtimeGenesisConfig);
+    _.merge((runtime.runtime_genesis_config || runtime), config.relaychain.overrides);
   }
 
   // genesis parachains


### PR DESCRIPTION
Looks like chainspecs for rococo & polkadot have a little bit different format. Specifically `rococo` has some extra key `runtime_genesis_config` while the polkdot does not. It seems that issue has been fixed partially for `paras` pallet initialization

https://github.com/open-web3-stack/parachain-launch/blob/master/src/index.ts#L219

but hrmp pallet initialization is still broken (hrmp config from config file is ignored).

This PR fixes the problem