### PR TITLE
Fix potential truncated chain spec stdout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,19 +78,20 @@ const stripChainspecJsonName = (chain: string) => {
  * @param chain
  */
 const getChainspec = (image: string, chain: string) => {
-  let res;
+  const outputChainSpec = `${chain}-${new Date().toISOString().slice(0, 10)}.json`;
   if (chain.endsWith('.json')) {
-    res = exec(
-      `docker run -v $(pwd)/${chain}:/${chain} --rm ${image} build-spec --chain=/${chain} --disable-default-bootnode`
+    exec(
+      `docker run -v $(pwd)/${chain}:/${chain} --rm ${image} build-spec --chain=/${chain} --disable-default-bootnode > ${outputChainSpec}`
     );
   } else {
-    res = exec(`docker run --rm ${image} build-spec --chain=${chain} --disable-default-bootnode`);
+    exec(`docker run --rm ${image} build-spec --chain=${chain} --disable-default-bootnode > ${outputChainSpec}`);
   }
 
   let spec;
 
   try {
-    spec = JSON.parse(res.stdout);
+    spec = JSON.parse(fs.readFileSync(outputChainSpec).toString());
+    fs.unlinkSync(outputChainSpec);
   } catch (e) {
     return fatal('build spec failed', e);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ const stripChainspecJsonName = (chain: string) => {
  * @param chain
  */
 const getChainspec = (image: string, chain: string) => {
-  const outputChainSpec = `${chain}-${new Date().toISOString().slice(0, 10)}.json`;
+  const outputChainSpec = `${shell.tempdir()}/${chain}-${new Date().toISOString().slice(0, 10)}.json`;
   if (chain.endsWith('.json')) {
     exec(
       `docker run -v $(pwd)/${chain}:/${chain} --rm ${image} build-spec --chain=/${chain} --disable-default-bootnode > ${outputChainSpec}`


### PR DESCRIPTION

This PR tries first to dump the chain spec to a local file and then read from it, instead of using `exec().stdout` directly.

The background is we have noticed a race condition in our CI, where we sometimes got truncated chain spec like this:
```
$ docker run --rm litentry/litentry-parachain:latest build-spec --chain=rococo-dev --disable-default-bootnode
Trace: Error: build spec failed SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at getChainspec (/home/runner/work/litentry-parachain/litentry-parachain/docker/node_modules/@open-web3/parachain-launch/lib/index.js:110:21)
    at generateParachainGenesisFile (/home/runner/work/litentry-parachain/litentry-parachain/docker/node_modules/@open-web3/parachain-launch/lib/index.js:308:18)
    at generate (/home/runner/work/litentry-parachain/litentry-parachain/docker/node_modules/@open-web3/parachain-launch/lib/index.js:404:9)
    at fatal (/home/runner/work/litentry-parachain/litentry-parachain/docker/node_modules/@open-web3/parachain-launch/lib/index.js:79:13)
    at getChainspec (/home/runner/work/litentry-parachain/litentry-parachain/docker/node_modules/@open-web3/parachain-launch/lib/index.js:113:16)
    at generateParachainGenesisFile (/home/runner/work/litentry-parachain/litentry-parachain/docker/node_modules/@open-web3/parachain-launch/lib/index.js:308:18)
    at generate (/home/runner/work/litentry-parachain/litentry-parachain/docker/node_modules/@open-web3/parachain-launch/lib/index.js:[40](https://github.com/litentry/litentry-parachain/actions/runs/5988781615/job/16250635843?pr=2016#step:8:41)4:9)
```

I also have a minimal reproducible program, see https://github.com/litentry/litentry-parachain/issues/2081#issuecomment-1698564468

In the end I believe it's related to the fact that the stdout is buffered, see https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback